### PR TITLE
feat(streams): use 'string' as type for KELs

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "js"
   ],
   "devDependencies": {
-    "@jolocom/native-core": "^1.0.0-rc2",
+    "@jolocom/native-core": "^1.0.0-rc4",
     "@jolocom/sdk-storage-typeorm": "^2.0.8",
     "@types/jest": "^24.0.23",
     "did-resolver": "2.0.0",

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -42,11 +42,11 @@ describe("Local DID Resolver", () => {
       const { inceptionEvent, id } = icp_data
 
       // save the event to the DB, and resolve the DID
-      await registrar.update([inceptionEvent])
+      await registrar.update(inceptionEvent)
       const ddo = await resolver.resolve(id)
 
       // now do it again, resolved DID doc should be unchanged
-      await registrar.update([inceptionEvent])
+      await registrar.update(inceptionEvent)
       const ddoUpdated = await resolver.resolve(id)
 
       return expect(ddoUpdated).toEqual(ddo)

--- a/tests/sdk.test.ts
+++ b/tests/sdk.test.ts
@@ -74,12 +74,12 @@ describe("Local DID Resolver", () => {
       
       const { inceptionEvent } = icp_data
 
-      const res = await registrar.update([inceptionEvent])
+      const res = await registrar.update(inceptionEvent)
 
       // ensure appending an existing event doesnt fail
-      expect(registrar.update([inceptionEvent])).resolves.toBeTruthy()
+      expect(registrar.update(inceptionEvent)).resolves.toBeTruthy()
 
-      const testDDO = await validateEvents(JSON.stringify([inceptionEvent]))
+      const testDDO = await validateEvents(inceptionEvent)
 
       const localResolver = new Resolver(resolver)
 

--- a/ts/db.ts
+++ b/ts/db.ts
@@ -1,28 +1,28 @@
 interface DbState {
-  [did: string]: string[]
+  [did: string]: string
 }
 
 // SMALL MOCK IMPLEMENTATION, this will mutate the initialState
 export const createDb = (
   initialState: DbState = {}
 ): InternalDb => ({
-    append: async (id: string, events: string[]) => {
+    append: async (id: string, events: string) => {
       if (!initialState[id] || !initialState[id].length) {
-        initialState[id] = []
+        initialState[id] = ""
       }
 
       initialState[id] = initialState[id].concat(events)
       return true
     },
     delete: async (id: string) => {
-      initialState[id] = [] 
+      initialState[id] = "" 
       return true
     },
-    read: async id => initialState[id] || [],
+    read: async id => initialState[id] || "",
   })
 
 export interface InternalDb {
-  read: (id: string) => Promise<string[]>
-  append: (id: string, events: string[]) => Promise<boolean>
+  read: (id: string) => Promise<string>
+  append: (id: string, events: string) => Promise<boolean>
   delete: (id: string) => Promise<boolean>,
 }

--- a/ts/index.ts
+++ b/ts/index.ts
@@ -29,7 +29,7 @@ export const getRegistrar = <T, C>(cfg: {
 }) => ({
     update: async (events: string) => {
       try {
-        const keyEventId = await cfg.getIdFromEvent(events[0])
+        const keyEventId = await cfg.getIdFromEvent(events)
         const previousEvents = await cfg.dbInstance.read(keyEventId) || ""
 
         // TODO

--- a/yarn.lock
+++ b/yarn.lock
@@ -700,6 +700,36 @@
     detect-node "^2.0.4"
     node-fetch "^2.6.0"
 
+"@jolocom/native-core-node-10-darwin-x64@^1.0.0-rc1":
+  version "1.0.0-rc0"
+  resolved "https://registry.yarnpkg.com/@jolocom/native-core-node-10-darwin-x64/-/native-core-node-10-darwin-x64-1.0.0-rc0.tgz#8ebe17864e5cd17feb2353401351b683c744828e"
+  integrity sha512-DmNUBapYVISb2XXU3b/WWHr+2PAL8O2n+qaFsicvVAzt/REWyU0++hH86iBxNXefYQ4WAVyaIOIKwc/D9kA10g==
+
+"@jolocom/native-core-node-10-linux-x64@^1.0.0-rc1":
+  version "1.0.0-rc1"
+  resolved "https://registry.yarnpkg.com/@jolocom/native-core-node-10-linux-x64/-/native-core-node-10-linux-x64-1.0.0-rc1.tgz#d78cecb783316c03fcc5765ddc92520c6908153f"
+  integrity sha512-B/TyDzIsTKrdahIq1zvZRt/4WnGy7FOpzQbxS/k84lvYn450ebynKiAHKNjmpyeU281KCZXgiURC2jUMqoxIGA==
+
+"@jolocom/native-core-node-12-darwin-x64@^1.0.0-rc1":
+  version "1.0.0-rc0"
+  resolved "https://registry.yarnpkg.com/@jolocom/native-core-node-12-darwin-x64/-/native-core-node-12-darwin-x64-1.0.0-rc0.tgz#750241acf6c50e90820f071ab55444bc02a6589f"
+  integrity sha512-JgzSzXSmpG/oPgM0lXQ1G8tWvgGoVyW5xCdx6hQJqETzyVdMa1/F1GwBcOP2+bAVj8ltmfZ0TWwUMgJpfcAjfw==
+
+"@jolocom/native-core-node-12-linux-x64@^1.0.0-rc1":
+  version "1.0.0-rc1"
+  resolved "https://registry.yarnpkg.com/@jolocom/native-core-node-12-linux-x64/-/native-core-node-12-linux-x64-1.0.0-rc1.tgz#56018b13ea0c7ca6eaa4a104a2d7482a6faa6cc5"
+  integrity sha512-9XH1OHnu0fiskE1zhN/UjDv9668kTKyWuWWiTGek/dUN3ZlWcXrelgs5JkDjK6HhqazlNmm2zHIrppX9XgBM7Q==
+
+"@jolocom/native-core-node-14-darwin-x64@^1.0.0-rc1":
+  version "1.0.0-rc0"
+  resolved "https://registry.yarnpkg.com/@jolocom/native-core-node-14-darwin-x64/-/native-core-node-14-darwin-x64-1.0.0-rc0.tgz#311e71310c637aa976fabf0a376ecd5ac6722134"
+  integrity sha512-VsG1544/i743AkQoSHeA7Hq8dMHhq1R3hSoCQ+8PmesfmkcbXvy0juqb/RSfSYE6XlUFPJ8EvhfkEf2T9gloFw==
+
+"@jolocom/native-core-node-14-linux-x64@^1.0.0-rc1":
+  version "1.0.0-rc1"
+  resolved "https://registry.yarnpkg.com/@jolocom/native-core-node-14-linux-x64/-/native-core-node-14-linux-x64-1.0.0-rc1.tgz#98126121425e113ee2825ef55967060806d01b85"
+  integrity sha512-pLW3g57t6NWDoNlwCUdmuJJiZcNtzTQvZyEUi7/RDroRKTAzskvqfNN+rFQS1/id/QiBlscS5JmYPZ31JRAu1Q==
+
 "@jolocom/native-core-node-darwin-x64@^1.0.0-rc14":
   version "1.0.0-rc14"
   resolved "https://registry.yarnpkg.com/@jolocom/native-core-node-darwin-x64/-/native-core-node-darwin-x64-1.0.0-rc14.tgz#e1d835543497aff7d8b3cb5699088b359952d504"
@@ -717,6 +747,18 @@
   optionalDependencies:
     "@jolocom/native-core-node-darwin-x64" "^1.0.0-rc14"
     "@jolocom/native-core-node-linux-x64" "^1.0.0-rc14"
+
+"@jolocom/native-core@^1.0.0-rc4":
+  version "1.0.0-rc4"
+  resolved "https://registry.yarnpkg.com/@jolocom/native-core/-/native-core-1.0.0-rc4.tgz#51c4c15f36aba4d13fdf426d54e743241e66b0b0"
+  integrity sha512-+NGs453Dw0MH5KSlQEWbztY1L2VDzGNcy3N2XZ9GRaRN6iYNUdxz85TuJcTbnVlUujvIFhB3xHWnqWxzEou/+A==
+  optionalDependencies:
+    "@jolocom/native-core-node-10-darwin-x64" "^1.0.0-rc1"
+    "@jolocom/native-core-node-10-linux-x64" "^1.0.0-rc1"
+    "@jolocom/native-core-node-12-darwin-x64" "^1.0.0-rc1"
+    "@jolocom/native-core-node-12-linux-x64" "^1.0.0-rc1"
+    "@jolocom/native-core-node-14-darwin-x64" "^1.0.0-rc1"
+    "@jolocom/native-core-node-14-linux-x64" "^1.0.0-rc1"
 
 "@jolocom/protocol-ts@^0.5.1":
   version "0.5.1"


### PR DESCRIPTION
text streams are how KELs are generally transmitted and stored. while the string[] api could be maintained, it would involve the addition of some extra logic for splitting event streams for no gain and without forwards compatibility